### PR TITLE
収入支出一覧に検索・ページネーションをいれる

### DIFF
--- a/household_account_book_app/Gemfile
+++ b/household_account_book_app/Gemfile
@@ -54,6 +54,8 @@ gem 'ransack'
 
 gem 'kaminari'
 
+gem 'kaminari-i18n'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows], require: "debug/prelude"

--- a/household_account_book_app/Gemfile
+++ b/household_account_book_app/Gemfile
@@ -52,6 +52,8 @@ gem 'draper'
 
 gem 'ransack'
 
+gem 'kaminari'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows], require: "debug/prelude"

--- a/household_account_book_app/Gemfile
+++ b/household_account_book_app/Gemfile
@@ -50,6 +50,8 @@ gem 'groupdate'
 
 gem 'draper'
 
+gem 'ransack'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows], require: "debug/prelude"

--- a/household_account_book_app/Gemfile.lock
+++ b/household_account_book_app/Gemfile.lock
@@ -277,6 +277,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    ransack (4.2.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -437,6 +441,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-i18n
   rails-mermaid_erd
+  ransack
   rspec-rails
   rubocop
   rubocop-rails

--- a/household_account_book_app/Gemfile.lock
+++ b/household_account_book_app/Gemfile.lock
@@ -164,6 +164,18 @@ GEM
     json (2.7.2)
     jwt (2.9.3)
       base64
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
     logger (1.6.1)
     loofah (2.22.0)
@@ -436,6 +448,7 @@ DEPENDENCIES
   groupdate
   importmap-rails
   jbuilder
+  kaminari
   puma (>= 5.0)
   rails (~> 7.2.1)
   rails-controller-testing

--- a/household_account_book_app/Gemfile.lock
+++ b/household_account_book_app/Gemfile.lock
@@ -176,6 +176,9 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    kaminari-i18n (0.5.0)
+      kaminari
+      rails
     language_server-protocol (3.17.0.3)
     logger (1.6.1)
     loofah (2.22.0)
@@ -449,6 +452,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kaminari
+  kaminari-i18n
   puma (>= 5.0)
   rails (~> 7.2.1)
   rails-controller-testing

--- a/household_account_book_app/app/assets/stylesheets/custom.scss
+++ b/household_account_book_app/app/assets/stylesheets/custom.scss
@@ -108,6 +108,8 @@ header {
 }
 
 .container-home-afer-signin {
+  display: flex;
+  flex-direction: column;
   padding-bottom: 20px;
   p {
     font-size: 30px;
@@ -170,6 +172,27 @@ header {
         background-color: #000000;
         color: white;
       }
+    }
+  }
+  .index-income-and-expense {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    border: 3px solid black;
+    border-radius: 10px;
+    width: 100%;
+    margin-top: 20px;
+    .form {
+      display: flex;
+      float: left;
+      gap: 20px;
+      .button {
+        background-color: #000000;
+        color: white;
+      }
+    }
+    .serach-result {
+      padding-top: 10px;
     }
   }
 }
@@ -259,7 +282,7 @@ header {
     float: left;
     width: 100%;
     height: 500px;
-
+    margin-bottom: 10px;
     .grath-income-this-year {
       border: 3px solid black;
       border-radius: 10px;

--- a/household_account_book_app/app/assets/stylesheets/custom.scss
+++ b/household_account_book_app/app/assets/stylesheets/custom.scss
@@ -193,6 +193,9 @@ header {
     }
     .serach-result {
       padding-top: 10px;
+      .pagination .page {
+        margin-right: 50px;
+      }
     }
   }
 }

--- a/household_account_book_app/app/assets/stylesheets/custom.scss
+++ b/household_account_book_app/app/assets/stylesheets/custom.scss
@@ -192,6 +192,9 @@ header {
       }
     }
     .serach-result {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
       padding-top: 10px;
       .pagination .page {
         margin-right: 50px;

--- a/household_account_book_app/app/controllers/households_controller.rb
+++ b/household_account_book_app/app/controllers/households_controller.rb
@@ -23,7 +23,7 @@ class HouseholdsController < ApplicationController
       @q.transaction_type_in = transaction_types
     end
     @q.category_id_eq = params[:category_id] if params[:category_id].present?
-    @households = @q.result(distinct: true).order(date: :desc)
+    @households = @q.result(distinct: true).order(date: :desc).page(params[:page]).per(50)
   end
 
   def create

--- a/household_account_book_app/app/controllers/households_controller.rb
+++ b/household_account_book_app/app/controllers/households_controller.rb
@@ -5,6 +5,7 @@ class HouseholdsController < ApplicationController
     @financial_summary_this_year = current_user.households.financial_summary_this_year
     @financial_summary_this_month = current_user.households.financial_summary_this_month
     @years_months = current_user.households.distinct_years_months
+    params[:q] ||= {}
     @q = current_user.households.ransack(params[:q])
     @households = @q.result
                     .eager_load(:category)

--- a/household_account_book_app/app/controllers/households_controller.rb
+++ b/household_account_book_app/app/controllers/households_controller.rb
@@ -25,8 +25,8 @@ class HouseholdsController < ApplicationController
       @q.transaction_type_in = transaction_types
     end
     @q.category_id_eq = params[:category_id] if params[:category_id].present?
-    @total_amount_households = @q.result(distinct: true).sum(:amount)
-    @households = @q.result(distinct: true).order(date: :desc).page(params[:page]).per(50)
+    @total_amount_households = @q.result.sum(:amount)
+    @households = @q.result.order(date: :desc).page(params[:page]).per(50)
   end
 
   def create

--- a/household_account_book_app/app/controllers/households_controller.rb
+++ b/household_account_book_app/app/controllers/households_controller.rb
@@ -21,15 +21,15 @@ class HouseholdsController < ApplicationController
     incomes = current_user.households.income
     @incomes_this_year = incomes.this_year
     @incomes_grath_data_this_year = @incomes_this_year.group_by_month(:date, format: '%B').sum(:amount)
-    @incomes_grath_data_this_month = incomes.this_month.group(:name).sum(:amount)
+    @incomes_grath_data_this_month = incomes.this_month.joins(:category).group('categories.name').sum(:amount)
   end
 
   def expense
     households = current_user.households
     @all_expenses_this_year = households.all_expense.this_year.decorate
-    @all_expenses_grath_data_this_month = households.all_expense.this_month.group(:name).sum(:amount)
-    @fixed_expenses_grath_data_this_month = households.fixed_expense.this_month.group(:name).sum(:amount)
-    @variable_expenses_grath_data_this_month = households.variable_expense.this_month.group(:name).sum(:amount)
+    @all_expenses_grath_data_this_month = households.all_expense.this_month.joins(:category).group('categories.name').sum(:amount)
+    @fixed_expenses_grath_data_this_month = households.fixed_expense.this_month.joins(:category).group('categories.name').sum(:amount)
+    @variable_expenses_grath_data_this_month = households.variable_expense.this_month.joins(:category).group('categories.name').sum(:amount)
     fixed_expenses_data = households.fixed_expense.this_year.group_by_month(:date, format: '%B').sum(:amount)
     variable_expenses_data = households.variable_expense.this_year.group_by_month(:date, format: '%B').sum(:amount)
     @expenses_grath_data_this_year = [{ name: '固定費', data: fixed_expenses_data },

--- a/household_account_book_app/app/controllers/households_controller.rb
+++ b/household_account_book_app/app/controllers/households_controller.rb
@@ -8,7 +8,7 @@ class HouseholdsController < ApplicationController
     @q = current_user.households.ransack(params[:q])
     @households = @q.result
                     .eager_load(:category)
-                    .order(date: :desc)
+                    .order(date: :desc, id: :asc)
                     .page(params[:page])
                     .per(50)
     @total_amount_households = @households.sum(:amount)

--- a/household_account_book_app/app/controllers/households_controller.rb
+++ b/household_account_book_app/app/controllers/households_controller.rb
@@ -26,7 +26,7 @@ class HouseholdsController < ApplicationController
     end
     @q.category_id_eq = params[:category_id] if params[:category_id].present?
     @total_amount_households = @q.result.sum(:amount)
-    @households = @q.result.order(date: :desc).page(params[:page]).per(50)
+    @households = @q.result.eager_load(:category).order(date: :desc).page(params[:page]).per(50)
   end
 
   def create
@@ -42,14 +42,14 @@ class HouseholdsController < ApplicationController
 
   def income
     incomes = current_user.households.income
-    @incomes_this_year = incomes.this_year.decorate
+    @incomes_this_year = incomes.this_year.eager_load(:category).decorate
     @incomes_grath_data_this_month = incomes.this_month.joins(:category).group('categories.name').sum(:amount)
     @incomes_grath_data_this_year = incomes.this_year.group_by_month(:date, format: '%B').sum(:amount)
   end
 
   def expense
     households = current_user.households
-    @all_expenses_this_year = households.all_expense.this_year.decorate
+    @all_expenses_this_year = households.all_expense.this_year.eager_load(:category).decorate
     @all_expenses_grath_data_this_month = households.all_expense.this_month.joins(:category).group('categories.name').sum(:amount)
     @fixed_expenses_grath_data_this_month = households.fixed_expense.this_month.joins(:category).group('categories.name').sum(:amount)
     @variable_expenses_grath_data_this_month = households.variable_expense.this_month.joins(:category).group('categories.name').sum(:amount)

--- a/household_account_book_app/app/controllers/households_controller.rb
+++ b/household_account_book_app/app/controllers/households_controller.rb
@@ -26,6 +26,7 @@ class HouseholdsController < ApplicationController
     end
     @q.category_id_eq = params[:category_id] if params[:category_id].present?
     @households = @q.result(distinct: true).order(date: :desc).page(params[:page]).per(50)
+    @total_amount_households = @households.sum(:amount)
   end
 
   def create

--- a/household_account_book_app/app/controllers/households_controller.rb
+++ b/household_account_book_app/app/controllers/households_controller.rb
@@ -6,10 +6,11 @@ class HouseholdsController < ApplicationController
     @financial_summary_this_month = current_user.households.financial_summary_this_month
     @years_months = current_user.households.distinct_years_months
     @q = current_user.households.ransack(params[:q])
-    if params[:year_month].present?
-      year, month = params[:year_month].split('-')
-      @q.date_eq = "#{year}-#{month}"
-    end
+    year, month = params[:date].split('-').map(&:to_i)
+    start_date = Date.new(year, month, 1)
+    end_date = start_date.end_of_month
+    @q.date_gteq = start_date
+    @q.date_lteq = end_date
     if params[:transaction_type].present?
       transaction_types = case params[:transaction_type]
                           when 'income'
@@ -22,7 +23,7 @@ class HouseholdsController < ApplicationController
       @q.transaction_type_in = transaction_types
     end
     @q.category_id_eq = params[:category_id] if params[:category_id].present?
-    @households = @q.result.order(date: :desc)
+    @households = @q.result(distinct: true).order(date: :desc)
   end
 
   def create

--- a/household_account_book_app/app/controllers/households_controller.rb
+++ b/household_account_book_app/app/controllers/households_controller.rb
@@ -7,12 +7,12 @@ class HouseholdsController < ApplicationController
     @years_months = current_user.households.distinct_years_months
     params[:q] ||= {}
     @q = current_user.households.ransack(params[:q])
+    @total_amount_households = @q.result.sum(:amount)
     @households = @q.result
                     .eager_load(:category)
                     .order(date: :desc, id: :asc)
                     .page(params[:page])
                     .per(50)
-    @total_amount_households = @households.sum(:amount)
   end
 
   def create

--- a/household_account_book_app/app/controllers/households_controller.rb
+++ b/household_account_book_app/app/controllers/households_controller.rb
@@ -7,9 +7,6 @@ class HouseholdsController < ApplicationController
     @years_months = current_user.households.distinct_years_months
     @q = current_user.households.ransack(params[:q])
     @households = @q.result
-                    .in_date_range(params[:date])
-                    .transaction_type_filter(params[:transaction_type])
-                    .category_filter(params[:category_id])
                     .eager_load(:category)
                     .order(date: :desc)
                     .page(params[:page])

--- a/household_account_book_app/app/controllers/households_controller.rb
+++ b/household_account_book_app/app/controllers/households_controller.rb
@@ -6,11 +6,13 @@ class HouseholdsController < ApplicationController
     @financial_summary_this_month = current_user.households.financial_summary_this_month
     @years_months = current_user.households.distinct_years_months
     @q = current_user.households.ransack(params[:q])
-    year, month = params[:date].split('-').map(&:to_i)
-    start_date = Date.new(year, month, 1)
-    end_date = start_date.end_of_month
-    @q.date_gteq = start_date
-    @q.date_lteq = end_date
+    if params[:date].present? && params[:date] != ''
+      year, month = params[:date].split('-').map(&:to_i)
+      start_date = Date.new(year, month, 1)
+      end_date = start_date.end_of_month
+      @q.date_gteq = start_date
+      @q.date_lteq = end_date
+    end
     if params[:transaction_type].present?
       transaction_types = case params[:transaction_type]
                           when 'income'

--- a/household_account_book_app/app/controllers/households_controller.rb
+++ b/household_account_book_app/app/controllers/households_controller.rb
@@ -25,8 +25,8 @@ class HouseholdsController < ApplicationController
       @q.transaction_type_in = transaction_types
     end
     @q.category_id_eq = params[:category_id] if params[:category_id].present?
+    @total_amount_households = @q.result(distinct: true).sum(:amount)
     @households = @q.result(distinct: true).order(date: :desc).page(params[:page]).per(50)
-    @total_amount_households = @households.sum(:amount)
   end
 
   def create

--- a/household_account_book_app/app/helpers/households_helper.rb
+++ b/household_account_book_app/app/helpers/households_helper.rb
@@ -1,4 +1,5 @@
 module HouseholdsHelper
+  include Ransack::Helpers::FormHelper
   def households_transahion_type_i18n_options
     Household.transaction_types.keys.map { |key| [I18n.t("transaction_type.#{key}"), key] }
   end

--- a/household_account_book_app/app/models/category.rb
+++ b/household_account_book_app/app/models/category.rb
@@ -1,11 +1,11 @@
 class Category < ApplicationRecord
   belongs_to :user
   validates :name, presence: true, length: { maximum: 20 }
-  def self.ransackable_attributes(auth_object = nil)
+  def self.ransackable_attributes(_auth_object = nil)
     %w[id name user_id created_at updated_at]
   end
 
-  def self.ransackable_associations(auth_object = nil)
+  def self.ransackable_associations(_auth_object = nil)
     ['user']
   end
 end

--- a/household_account_book_app/app/models/category.rb
+++ b/household_account_book_app/app/models/category.rb
@@ -1,4 +1,11 @@
 class Category < ApplicationRecord
   belongs_to :user
   validates :name, presence: true, length: { maximum: 20 }
+  def self.ransackable_attributes(auth_object = nil)
+    %w[id name user_id created_at updated_at]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    ['user']
+  end
 end

--- a/household_account_book_app/app/models/household.rb
+++ b/household_account_book_app/app/models/household.rb
@@ -26,11 +26,6 @@ class Household < ApplicationRecord
   scope :this_month, lambda {
     where(date: Time.current.all_month)
   }
-  scope :distinct_years_months, lambda {
-    select("DISTINCT strftime('%Y', date) AS year, strftime('%m', date) AS month")
-      .order('year DESC, month DESC')
-      .map { |record| [record.year, record.month] }
-  }
 
   FinancialSummaryStruct = Struct.new(:total_income, :total_expense, :net_balance)
 
@@ -50,5 +45,11 @@ class Household < ApplicationRecord
 
   def self.ransackable_attributes(auth_object = nil)
     super + ['date']
+  end
+
+  def self.distinct_years_months
+    select("DISTINCT strftime('%Y', date) AS year, strftime('%m', date) AS month")
+      .order('year DESC, month DESC')
+      .map { |record| [record.year, record.month] }
   end
 end

--- a/household_account_book_app/app/models/household.rb
+++ b/household_account_book_app/app/models/household.rb
@@ -44,6 +44,7 @@ class Household < ApplicationRecord
       all
     end
   }
+
   scope :category_id_eq, lambda { |category_id|
     where(category_id:) if category_id.present?
   }
@@ -68,11 +69,11 @@ class Household < ApplicationRecord
     super + ['date']
   end
 
-  def self.ransackable_scopes(auth_object = nil)
+  def self.ransackable_scopes(_auth_object = nil)
     %i[in_date_range transaction_type_in category_id_eq]
   end
 
-  def self.ransackable_associations(auth_object = nil)
+  def self.ransackable_associations(_auth_object = nil)
     %w[category user]
   end
 

--- a/household_account_book_app/app/models/household.rb
+++ b/household_account_book_app/app/models/household.rb
@@ -49,7 +49,6 @@ class Household < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    %w[amount category_id created_at date id id_value name transaction_type updated_at
-       user_id]
+    super + ['date']
   end
 end

--- a/household_account_book_app/app/models/household.rb
+++ b/household_account_book_app/app/models/household.rb
@@ -26,16 +26,16 @@ class Household < ApplicationRecord
   scope :this_month, lambda {
     where(date: Time.current.all_month)
   }
-  scope :in_date_range, lambda { |date_param|
-    if date_param.present? && date_param != ''
-      year, month = date_param.split('-').map(&:to_i)
+  scope :in_date_range, lambda { |date|
+    if date.present? && date != ''
+      year, month = date.split('-').map(&:to_i)
       start_date = Date.new(year, month, 1)
       end_date = start_date.end_of_month
       where(date: start_date..end_date)
     end
   }
-  scope :transaction_type_filter, lambda { |transaction_type_param|
-    case transaction_type_param
+  scope :transaction_type_in, lambda { |transaction_type|
+    case transaction_type
     when 'income'
       where(transaction_type: 0)
     when 'expense'
@@ -44,7 +44,7 @@ class Household < ApplicationRecord
       all
     end
   }
-  scope :category_filter, lambda { |category_id|
+  scope :category_id_eq, lambda { |category_id|
     where(category_id:) if category_id.present?
   }
 
@@ -66,6 +66,14 @@ class Household < ApplicationRecord
 
   def self.ransackable_attributes(auth_object = nil)
     super + ['date']
+  end
+
+  def self.ransackable_scopes(auth_object = nil)
+    %i[in_date_range transaction_type_in category_id_eq]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[category user]
   end
 
   def self.distinct_years_months

--- a/household_account_book_app/app/models/household.rb
+++ b/household_account_book_app/app/models/household.rb
@@ -26,6 +26,27 @@ class Household < ApplicationRecord
   scope :this_month, lambda {
     where(date: Time.current.all_month)
   }
+  scope :in_date_range, lambda { |date_param|
+    if date_param.present? && date_param != ''
+      year, month = date_param.split('-').map(&:to_i)
+      start_date = Date.new(year, month, 1)
+      end_date = start_date.end_of_month
+      where(date: start_date..end_date)
+    end
+  }
+  scope :transaction_type_filter, lambda { |transaction_type_param|
+    case transaction_type_param
+    when 'income'
+      where(transaction_type: 0)
+    when 'expense'
+      where(transaction_type: [1, 2])
+    else
+      all
+    end
+  }
+  scope :category_filter, lambda { |category_id|
+    where(category_id:) if category_id.present?
+  }
 
   FinancialSummaryStruct = Struct.new(:total_income, :total_expense, :net_balance)
 

--- a/household_account_book_app/app/models/household.rb
+++ b/household_account_book_app/app/models/household.rb
@@ -47,4 +47,9 @@ class Household < ApplicationRecord
     net_balance = total_income - total_expense
     FinancialSummaryStruct.new(total_income:, total_expense:, net_balance:)
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[amount category_id created_at date id id_value name transaction_type updated_at
+       user_id]
+  end
 end

--- a/household_account_book_app/app/models/household.rb
+++ b/household_account_book_app/app/models/household.rb
@@ -77,6 +77,10 @@ class Household < ApplicationRecord
     %w[category user]
   end
 
+  def self.ransackable_scopes_skip_sanitize_args
+    [:category_id_eq]
+  end
+
   def self.distinct_years_months
     select("DISTINCT strftime('%Y', date) AS year, strftime('%m', date) AS month")
       .order('year DESC, month DESC')

--- a/household_account_book_app/app/models/household.rb
+++ b/household_account_book_app/app/models/household.rb
@@ -34,7 +34,7 @@ class Household < ApplicationRecord
       where(date: start_date..end_date)
     end
   }
-  scope :transaction_type_in, lambda { |transaction_type|
+  scope :filter_transaction_type, lambda { |transaction_type|
     case transaction_type
     when 'income'
       where(transaction_type: 0)
@@ -43,10 +43,6 @@ class Household < ApplicationRecord
     else
       all
     end
-  }
-
-  scope :category_id_eq, lambda { |category_id|
-    where(category_id:) if category_id.present?
   }
 
   FinancialSummaryStruct = Struct.new(:total_income, :total_expense, :net_balance)
@@ -70,7 +66,7 @@ class Household < ApplicationRecord
   end
 
   def self.ransackable_scopes(_auth_object = nil)
-    %i[in_date_range transaction_type_in category_id_eq]
+    %i[in_date_range filter_transaction_type]
   end
 
   def self.ransackable_associations(_auth_object = nil)

--- a/household_account_book_app/app/models/household.rb
+++ b/household_account_book_app/app/models/household.rb
@@ -26,6 +26,11 @@ class Household < ApplicationRecord
   scope :this_month, lambda {
     where(date: Time.current.all_month)
   }
+  scope :distinct_years_months, lambda {
+    select("DISTINCT strftime('%Y', date) AS year, strftime('%m', date) AS month")
+      .order('year DESC, month DESC')
+      .map { |record| [record.year, record.month] }
+  }
 
   FinancialSummaryStruct = Struct.new(:total_income, :total_expense, :net_balance)
 

--- a/household_account_book_app/app/views/households/expense.html.erb
+++ b/household_account_book_app/app/views/households/expense.html.erb
@@ -25,7 +25,7 @@
                 <% @all_expenses_this_year.each do |expense| %>
                 <div class="expense">
                     <p><%= expense.date%></p>
-                    <p><%= expense.name%></p>
+                    <p><%= expense.category.name%></p>
                     <p><%= expense.transaction_type_i18n%></p>
                     <p><%= number_to_currency(expense.amount)%></p>
                 </div>

--- a/household_account_book_app/app/views/households/income.html.erb
+++ b/household_account_book_app/app/views/households/income.html.erb
@@ -17,7 +17,7 @@
                 <% @incomes_this_year.each do |income| %>
                 <div class="income">
                     <p><%= income.date%></p>
-                    <p><%= income.name%></p>
+                    <p><%= income.category.name%></p>
                     <p><%= number_to_currency(income.amount)%></p>
                 </div>
                 <% end %>

--- a/household_account_book_app/app/views/households/index.html.erb
+++ b/household_account_book_app/app/views/households/index.html.erb
@@ -90,11 +90,13 @@
                     <div class="serach-result">
                         <% if @households.present? %>
                         <p>検索結果の合計金額<%= number_to_currency(@total_amount_households)%></p>
-                        <ul>
-                            <% @households.each do |household| %>
-                            <li><%= household.date %> - <%= household.category.name %> - <%= number_to_currency(household.amount) %></li>
-                            <% end %>
-                        </ul>
+                        <div class="index-households">
+                            <ul>
+                                <% @households.each do |household| %>
+                                <li><%= household.date %> - <%= household.category.name %> - <%= number_to_currency(household.amount) %></li>
+                                <% end %>
+                            </ul>
+                        </div>
                         <div class="pagination">
                             <%= paginate @households %>
                         </div>

--- a/household_account_book_app/app/views/households/index.html.erb
+++ b/household_account_book_app/app/views/households/index.html.erb
@@ -66,6 +66,38 @@
                     <% end %>
                 </div>
             </div>
+            <div class="index-income-and-expense">
+                <h1>収入と支出の一覧&検索</h1>
+                    <%= form_with(url: households_path, method: :get ) do |f| %>
+                    <div class="form">
+                        <div class="year-month">
+                            <%= f.label :year_month, "年月" %>
+                            <%= f.select :year_month, options_for_select([['すべて', '']] + @years_months.map { |year, month| ["#{year}年#{month}月", "#{year}-#{month}"] }), include_blank: "選択してください", class: "form-control" %>
+                        </div>
+                        <div class="transaction_type">
+                            <%= f.label :transaction_type, "分類" %>
+                            <%= f.select :transaction_type, options_for_select([['すべて', 'all'], ['収入だけ', 'income'], ['支出だけ', 'expense']], selected: params[:transaction_type]), include_blank: "選択してください", class: "form-control" %>
+                        </div>
+                        <div class="category">
+                            <%= f.label :category_id, "名目" %>
+                            <%= f.select :category_id, options_for_select([['すべて', '']] + Category.all.map { |category| [category.name, category.id] }, selected: params[:category_id]), include_blank: "選択してください", class: "form-control" %>
+                        </div>
+                        <%= submit_tag "検索", class: "button" %> 
+                    </div>                   
+                    <% end %>
+                    <div class="serach-result">
+                        <% if @households.present? %>
+                        <ul>
+                            <% @households.each do |household| %>
+                            <li><%= household.date %> - <%= household.category.name %> - <%= number_to_currency(household.amount) %></li>
+                            <% end %>
+                        </ul>
+                        <% else %>
+                        <p>該当するデータはありません。</p>
+                        <% end %>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </body>

--- a/household_account_book_app/app/views/households/index.html.erb
+++ b/household_account_book_app/app/views/households/index.html.erb
@@ -71,8 +71,8 @@
                     <%= form_with(url: households_path, method: :get ) do |f| %>
                     <div class="form">
                         <div class="year-month">
-                            <%= f.label :year_month, "年月" %>
-                            <%= f.select :year_month, options_for_select([['すべて', '']] + @years_months.map { |year, month| ["#{year}年#{month}月", "#{year}-#{month}"] }), include_blank: "選択してください", class: "form-control" %>
+                            <%= f.label :date, "年月" %>
+                            <%= f.select :date, options_for_select([['すべて', '']] + @years_months.map { |year, month| ["#{year}年#{month}月", "#{year}-#{month}"] }, selected: params[:date]), include_blank: "選択してください", class: "form-control" %>
                         </div>
                         <div class="transaction_type">
                             <%= f.label :transaction_type, "分類" %>

--- a/household_account_book_app/app/views/households/index.html.erb
+++ b/household_account_book_app/app/views/households/index.html.erb
@@ -88,7 +88,6 @@
                     </div>                   
                     <% end %>
                     <div class="serach-result">
-                        <%= @test%>
                         <% if @households.present? %>
                         <p>検索結果の合計金額<%= number_to_currency(@total_amount_households)%></p>
                         <div class="index-households">

--- a/household_account_book_app/app/views/households/index.html.erb
+++ b/household_account_book_app/app/views/households/index.html.erb
@@ -68,19 +68,19 @@
             </div>
             <div class="index-income-and-expense">
                 <h1>収入と支出の一覧&検索</h1>
-                    <%= form_with(url: households_path, method: :get ) do |f| %>
+                    <%= search_form_for @q, url: households_path, method: :get do |f| %>
                     <div class="form">
                         <div class="year-month">
-                            <%= f.label :date, "年月" %>
-                            <%= f.select :date, options_for_select([['すべて', '']] + @years_months.map { |year, month| ["#{year}年#{month}月", "#{year}-#{month}"] }, selected: params[:date]), include_blank: "選択してください", class: "form-control" %>
+                            <%= f.label :in_date_range, "年月" %>
+                            <%= f.select :in_date_range, options_for_select([['すべて', '']] + @years_months.map { |year, month| ["#{year}年#{month}月", "#{year}-#{month}"] }, selected: params[:q][:in_date_range]), include_blank: "選択してください", class: "form-control" %>
                         </div>
-                        <div class="transaction_type">
-                            <%= f.label :transaction_type, "分類" %>
-                            <%= f.select :transaction_type, options_for_select([['すべて', 'all'], ['収入だけ', 'income'], ['支出だけ', 'expense']], selected: params[:transaction_type]), include_blank: "選択してください", class: "form-control" %>
+                        <div class="transaction_type_in">
+                            <%= f.label :transaction_type_in, "分類" %>
+                            <%= f.select :transaction_type_in, options_for_select([['すべて', 'all'], ['収入だけ', 'income'], ['支出だけ', 'expense']], selected: params[:q][:transaction_type_in]), include_blank: "選択してください", class: "form-control" %>
                         </div>
-                        <div class="category">
-                            <%= f.label :category_id, "名目" %>
-                            <%= f.select :category_id, options_for_select([['すべて', '']] + Category.all.map { |category| [category.name, category.id] }, selected: params[:category_id]), include_blank: "選択してください", class: "form-control" %>
+                        <div class="category_id_eq">
+                            <%= f.label :category_id_eq, "名目" %>
+                            <%= f.select :category_id_eq, options_for_select([['すべて', '']] + Category.all.map { |category| [category.name, category.id] }, selected: params[:q][:category_id_eq]), include_blank: "選択してください", class: "form-control" %>
                         </div>
                         <%= submit_tag "検索", class: "button" %> 
                         <%= sort_link(@q, :date, "日付並べ替え") %>
@@ -88,6 +88,7 @@
                     </div>                   
                     <% end %>
                     <div class="serach-result">
+                        <%= @test%>
                         <% if @households.present? %>
                         <p>検索結果の合計金額<%= number_to_currency(@total_amount_households)%></p>
                         <div class="index-households">

--- a/household_account_book_app/app/views/households/index.html.erb
+++ b/household_account_book_app/app/views/households/index.html.erb
@@ -94,6 +94,9 @@
                             <li><%= household.date %> - <%= household.category.name %> - <%= number_to_currency(household.amount) %></li>
                             <% end %>
                         </ul>
+                        <div class="pagination">
+                            <%= paginate @households %>
+                        </div>
                         <% else %>
                         <p>該当するデータはありません。</p>
                         <% end %>

--- a/household_account_book_app/app/views/households/index.html.erb
+++ b/household_account_book_app/app/views/households/index.html.erb
@@ -83,6 +83,8 @@
                             <%= f.select :category_id, options_for_select([['すべて', '']] + Category.all.map { |category| [category.name, category.id] }, selected: params[:category_id]), include_blank: "選択してください", class: "form-control" %>
                         </div>
                         <%= submit_tag "検索", class: "button" %> 
+                        <%= sort_link(@q, :date, "日付並べ替え") %>
+                        <%= sort_link(@q, :amount, "金額並べ替え") %>
                     </div>                   
                     <% end %>
                     <div class="serach-result">

--- a/household_account_book_app/app/views/households/index.html.erb
+++ b/household_account_book_app/app/views/households/index.html.erb
@@ -70,13 +70,13 @@
                 <h1>収入と支出の一覧&検索</h1>
                     <%= search_form_for @q, url: households_path, method: :get do |f| %>
                     <div class="form">
-                        <div class="year-month">
+                        <div class="in_date_range">
                             <%= f.label :in_date_range, "年月" %>
                             <%= f.select :in_date_range, options_for_select([['すべて', '']] + @years_months.map { |year, month| ["#{year}年#{month}月", "#{year}-#{month}"] }, selected: params[:q][:in_date_range]), include_blank: "選択してください", class: "form-control" %>
                         </div>
-                        <div class="transaction_type_in">
-                            <%= f.label :transaction_type_in, "分類" %>
-                            <%= f.select :transaction_type_in, options_for_select([['すべて', 'all'], ['収入だけ', 'income'], ['支出だけ', 'expense']], selected: params[:q][:transaction_type_in]), include_blank: "選択してください", class: "form-control" %>
+                        <div class="filter_transaction_type">
+                            <%= f.label :filter_transaction_type, "分類" %>
+                            <%= f.select :filter_transaction_type, options_for_select([['すべて', 'all'], ['収入だけ', 'income'], ['支出だけ', 'expense']], selected: params[:q][:filter_transaction_type]), include_blank: "選択してください", class: "form-control" %>
                         </div>
                         <div class="category_id_eq">
                             <%= f.label :category_id_eq, "名目" %>

--- a/household_account_book_app/app/views/households/index.html.erb
+++ b/household_account_book_app/app/views/households/index.html.erb
@@ -89,6 +89,7 @@
                     <% end %>
                     <div class="serach-result">
                         <% if @households.present? %>
+                        <p>検索結果の合計金額<%= number_to_currency(@total_amount_households)%></p>
                         <ul>
                             <% @households.each do |household| %>
                             <li><%= household.date %> - <%= household.category.name %> - <%= number_to_currency(household.amount) %></li>

--- a/household_account_book_app/app/views/kaminari/_first_page.html.erb
+++ b/household_account_book_app/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+</span>

--- a/household_account_book_app/app/views/kaminari/_gap.html.erb
+++ b/household_account_book_app/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/household_account_book_app/app/views/kaminari/_last_page.html.erb
+++ b/household_account_book_app/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+</span>

--- a/household_account_book_app/app/views/kaminari/_next_page.html.erb
+++ b/household_account_book_app/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
+</span>

--- a/household_account_book_app/app/views/kaminari/_page.html.erb
+++ b/household_account_book_app/app/views/kaminari/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page<%= ' current' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+</span>

--- a/household_account_book_app/app/views/kaminari/_paginator.html.erb
+++ b/household_account_book_app/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/household_account_book_app/app/views/kaminari/_prev_page.html.erb
+++ b/household_account_book_app/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
+</span>

--- a/household_account_book_app/config/initializers/kaminari_config.rb
+++ b/household_account_book_app/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/household_account_book_app/config/locales/ja.yml
+++ b/household_account_book_app/config/locales/ja.yml
@@ -20,3 +20,10 @@ ja:
     income: "収入"
     fixed_expense: "固定費"
     variable_expense: "流動費"
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      next: "次 &rsaquo;"
+      previous: "&lsaquo; 前"
+      truncate: "&hellip;"

--- a/household_account_book_app/db/seeds.rb
+++ b/household_account_book_app/db/seeds.rb
@@ -1,9 +1,44 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+require 'faker'
+
+user = User.create!(user_name: 'nakatomotest', email: "nakatomotest@example.com", password: "nakatomotest", password_confirmation: "nakatomotest")
+
+income_categories_names = ["給料", "メルカリ", "youtube", "物販", "アルバイト"]
+expense_categories_names = ["食費", "交通費", "交際費", "書籍", "雑貨"]
+
+income_categories = (1..5).map do |id|
+  Category.create!(
+    id: id,
+    user: user,
+    name: income_categories_names[id - 1]
+  )
+end
+
+expense_categories = (6..10).map do |id|
+  Category.create!(
+    id: id,
+    user: user,
+    name: expense_categories_names[id - 6]
+  )
+end
+
+(1..12).each do |month|
+  100.times do
+    Household.create!(
+      user: user,
+      date: Date.new(2024, month, rand(1..28)),
+      transaction_type: 0,
+      category_id: income_categories.sample.id,
+      amount: rand(1_000..10_000)
+    )
+  end
+
+  100.times do
+    Household.create!(
+      user: user,
+      date: Date.new(2024, month, rand(1..28)),
+      transaction_type: [1, 2].sample, 
+      category_id: expense_categories.sample.id,
+      amount: rand(100..1_000)
+    )
+  end
+end

--- a/household_account_book_app/spec/controllers/households_controller_spec.rb
+++ b/household_account_book_app/spec/controllers/households_controller_spec.rb
@@ -105,8 +105,8 @@ RSpec.describe HouseholdsController, type: :controller do
     end
 
     it 'filters @households by category using ransack' do
-      get :index, params: { q: { category_id_eq: category_2.id } }
-      expect(assigns(:households)).to contain_exactly(fixed_expense, variable_expense, variable_expense_same_day)
+      get :index, params: { q: { category_id_eq: category_1.id } }
+      expect(assigns(:households)).to contain_exactly(income)
     end
 
     it 'orders @households by date desc and id asc' do

--- a/household_account_book_app/spec/controllers/households_controller_spec.rb
+++ b/household_account_book_app/spec/controllers/households_controller_spec.rb
@@ -65,12 +65,6 @@ RSpec.describe HouseholdsController, type: :controller do
       get :index
       expect(Household.financial_summary_this_month[:net_balance]).to eq(810)
     end
-
-    it 'assigns @years_months' do
-      get :index
-      expected = [%w[2024 11], %w[2024 10]]
-      expect(user.households.distinct_years_months).to eq(expected)
-    end
   end
 
   describe '#index search by ransack' do
@@ -87,6 +81,12 @@ RSpec.describe HouseholdsController, type: :controller do
     end
     let!(:variable_expense_same_day) do
       create(:household, transaction_type: 2, date: Date.new(2024, 6, 10), amount: 4000, user:, category: category_2)
+    end
+
+    it 'assigns @years_months' do
+      get :index
+      expected = [%w[2024 11], %w[2024 06]]
+      expect(user.households.distinct_years_months).to eq(expected)
     end
 
     it 'assigns @q with ransack query' do
@@ -115,7 +115,7 @@ RSpec.describe HouseholdsController, type: :controller do
     end
 
     it 'calculates @total_amount_households correctly' do
-      get :index, params: { q: { transaction_type_in: 'expense' } }
+      get :index, params: { q: { filter_transaction_type: 'expense' } }
       total_amount = fixed_expense.amount + variable_expense.amount + variable_expense_same_day.amount
       expect(assigns(:total_amount_households)).to eq(total_amount)
     end

--- a/household_account_book_app/spec/models/household_spec.rb
+++ b/household_account_book_app/spec/models/household_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Household, type: :model do
       end
     end
 
-    describe '.transaction_type_in' do
+    describe '.filter_transaction_type' do
       let!(:income_record) do
         create(:household, transaction_type: 0, date: '2024-11-01', amount: 4000, user:, category:)
       end
@@ -123,26 +123,11 @@ RSpec.describe Household, type: :model do
       end
 
       it 'filters income records' do
-        expect(described_class.transaction_type_in('income')).to contain_exactly(income_record)
+        expect(described_class.filter_transaction_type('income')).to contain_exactly(income_record)
       end
 
       it 'filters expense records' do
-        expect(described_class.transaction_type_in('expense')).to contain_exactly(expense_record)
-      end
-    end
-
-    describe '.category_id_eq' do
-      let!(:category1) { create(:category, user:) }
-      let!(:category2) { create(:category, user:) }
-      let!(:record) do
-        create(:household, transaction_type: 0, date: '2024-11-01', amount: 4000, user:, category: category1)
-      end
-      let!(:different_category_record) do
-        create(:household, transaction_type: 0, date: '2024-11-01', amount: 4000, user:, category: category2)
-      end
-
-      it 'filters records by category_id' do
-        expect(described_class.category_id_eq(category1.id)).to contain_exactly(record)
+        expect(described_class.filter_transaction_type('expense')).to contain_exactly(expense_record)
       end
     end
 

--- a/household_account_book_app/spec/models/household_spec.rb
+++ b/household_account_book_app/spec/models/household_spec.rb
@@ -97,8 +97,22 @@ RSpec.describe Household, type: :model do
                                                income_last_month, fixed_expense_last_month, variable_expense_last_month])
     end
 
-    it 'returnsfrom the current month when .this_month' do
+    it 'returns from the current month when .this_month' do
       expect(described_class.this_month).to eq([income_this_year, fixed_expense_this_year, variable_expense_this_year])
+    end
+
+    describe '.distinct_years_months' do
+      before do
+        @record1 = create(:household, transaction_type: 0, date: Date.new(2024, 5, 10), amount: 4000, user:, category:)
+        @record2 = create(:household, transaction_type: 1, date: Date.new(2024, 6, 10), amount: 4000, user:, category:)
+        @record3 = create(:household, transaction_type: 1, date: Date.new(2024, 6, 10), amount: 4000, user:, category:)
+        @record4 = create(:household, transaction_type: 1, date: Date.new(2023, 6, 10), amount: 4000, user:, category:)
+      end
+
+      it 'returns unique year and month combinations in descending order' do
+        expected = [%w[2024 06], %w[2024 05], %w[2023 06]]
+        expect(described_class.distinct_years_months).to eq(expected)
+      end
     end
   end
 end

--- a/household_account_book_app/spec/models/household_spec.rb
+++ b/household_account_book_app/spec/models/household_spec.rb
@@ -102,11 +102,17 @@ RSpec.describe Household, type: :model do
     end
 
     describe '.distinct_years_months' do
-      before do
-        @record1 = create(:household, transaction_type: 0, date: Date.new(2024, 5, 10), amount: 4000, user:, category:)
-        @record2 = create(:household, transaction_type: 1, date: Date.new(2024, 6, 10), amount: 4000, user:, category:)
-        @record3 = create(:household, transaction_type: 1, date: Date.new(2024, 6, 10), amount: 4000, user:, category:)
-        @record4 = create(:household, transaction_type: 1, date: Date.new(2023, 6, 10), amount: 4000, user:, category:)
+      let!(:record1) do
+        create(:household, transaction_type: 0, date: Date.new(2024, 5, 10), amount: 4000, user:, category:)
+      end
+      let!(:record2) do
+        create(:household, transaction_type: 1, date: Date.new(2024, 6, 10), amount: 4000, user:, category:)
+      end
+      let!(:record3) do
+        create(:household, transaction_type: 1, date: Date.new(2024, 6, 10), amount: 4000, user:, category:)
+      end
+      let!(:record4) do
+        create(:household, transaction_type: 0, date: Date.new(2023, 6, 10), amount: 4000, user:, category:)
       end
 
       it 'returns unique year and month combinations in descending order' do

--- a/household_account_book_app/spec/models/household_spec.rb
+++ b/household_account_book_app/spec/models/household_spec.rb
@@ -101,6 +101,51 @@ RSpec.describe Household, type: :model do
       expect(described_class.this_month).to eq([income_this_year, fixed_expense_this_year, variable_expense_this_year])
     end
 
+    describe '.in_date_range' do
+      let!(:record) do
+        create(:household, transaction_type: 0, date: '2024-11-01', amount: 4000, user:, category:)
+      end
+      let!(:different_month_record) do
+        create(:household, transaction_type: 0, date: '2024-12-01', amount: 4000, user:, category:)
+      end
+
+      it 'filters records within the specified month' do
+        expect(described_class.in_date_range('2024-11')).to contain_exactly(record)
+      end
+    end
+
+    describe '.transaction_type_in' do
+      let!(:income_record) do
+        create(:household, transaction_type: 0, date: '2024-11-01', amount: 4000, user:, category:)
+      end
+      let!(:expense_record) do
+        create(:household, transaction_type: 1, date: '2024-11-01', amount: 4000, user:, category:)
+      end
+
+      it 'filters income records' do
+        expect(described_class.transaction_type_in('income')).to contain_exactly(income_record)
+      end
+
+      it 'filters expense records' do
+        expect(described_class.transaction_type_in('expense')).to contain_exactly(expense_record)
+      end
+    end
+
+    describe '.category_id_eq' do
+      let!(:category1) { create(:category, user:) }
+      let!(:category2) { create(:category, user:) }
+      let!(:record) do
+        create(:household, transaction_type: 0, date: '2024-11-01', amount: 4000, user:, category: category1)
+      end
+      let!(:different_category_record) do
+        create(:household, transaction_type: 0, date: '2024-11-01', amount: 4000, user:, category: category2)
+      end
+
+      it 'filters records by category_id' do
+        expect(described_class.category_id_eq(category1.id)).to contain_exactly(record)
+      end
+    end
+
     describe '.distinct_years_months' do
       let!(:record1) do
         create(:household, transaction_type: 0, date: Date.new(2024, 5, 10), amount: 4000, user:, category:)


### PR DESCRIPTION
* 作業時間
   * 11/25　5h30m
   * 11/26　6h1m
   * 11/27　1h39m
合計　13h10m
* 作業内容
   *  何年、何月、(収入だけ、支出だけ、両方)、名目(例：給料、食費、すべてetc)を指定して、その範囲のデータを取得して一覧で表示
   * ページネーションを追加(1ページにつき50件ずつ表示)
   * seedであらかじめ収入、支出のデータを用意しておく
   * 年、月の選択はプルダウンメニュー(DBに収入or支出が登録されている年と月を表示)
   * 検索ボタンを押すと一覧が表示される
   * 日付のソート順を降順にする
   * 各列にソート機能を追加(ransackを使用)
   * 検索結果一覧に表示されたものの合計を表示
   * 円グラフに表示するnameをcategoryのnameに変更
   * contorollerのテスト controllerの#indexで新規にインスタンス変数が生成されているか
   * modelのテスト scopeのテスト
* 備考
  * home画面に実装しました
  * 理由
　 収入と支出どちらも検索できるため
* 検索動作
![検索動作](https://github.com/user-attachments/assets/93d1fda1-9577-49cc-8631-eec69ca62d8f)
